### PR TITLE
refactor: convert woodcutting tasks to use new task system

### DIFF
--- a/src/engine/world/skill-util/harvest-skill.ts
+++ b/src/engine/world/skill-util/harvest-skill.ts
@@ -13,6 +13,11 @@ import { findItem } from '@engine/config/config-handler';
 import { activeWorld } from '@engine/world';
 import { loopingEvent } from '@engine/plugins';
 
+/**
+ * Check if a player can harvest a given {@link IHarvestable}
+ *
+ * @returns a {@link HarvestTool} if the player can harvest the object, or undefined if they cannot.
+ */
 export function canInitiateHarvest(player: Player, target: IHarvestable, skill: Skill): undefined | HarvestTool {
     if (!target) {
         switch (skill) {

--- a/src/plugins/skills/woodcutting/chance.ts
+++ b/src/plugins/skills/woodcutting/chance.ts
@@ -1,0 +1,14 @@
+import { randomBetween } from '@engine/util';
+import { IHarvestable } from '@engine/world/config';
+
+export const canCut = (
+    tree: IHarvestable,
+    toolLevel: number,
+    woodcuttingLevel: number
+): boolean => {
+    const successChance = randomBetween(0, 255);
+
+    const percentNeeded =
+        tree.baseChance + toolLevel + woodcuttingLevel;
+    return successChance <= percentNeeded;
+};

--- a/src/plugins/skills/woodcutting/index.ts
+++ b/src/plugins/skills/woodcutting/index.ts
@@ -2,7 +2,7 @@ import {
     ObjectInteractionActionHook,
 } from '@engine/action';
 import { getTreeIds } from '@engine/world/config/harvestable-object';
-import { activate, canActivate, onComplete } from './woodcutting-task';
+import { runWoodcuttingTask } from './woodcutting-task';
 
 
 export default {
@@ -12,12 +12,8 @@ export default {
             type: 'object_interaction',
             options: [ 'chop down', 'chop' ],
             objectIds: getTreeIds(),
-            strength: 'normal',
-            task: {
-                canActivate,
-                activate,
-                onComplete,
-                interval: 1
+            handler: ({ player, object }) => {
+                runWoodcuttingTask(player, object);
             }
         } as ObjectInteractionActionHook
     ]

--- a/src/plugins/skills/woodcutting/index.ts
+++ b/src/plugins/skills/woodcutting/index.ts
@@ -1,0 +1,24 @@
+import {
+    ObjectInteractionActionHook,
+} from '@engine/action';
+import { getTreeIds } from '@engine/world/config/harvestable-object';
+import { activate, canActivate, onComplete } from './woodcutting-task';
+
+
+export default {
+    pluginId: 'rs:woodcutting',
+    hooks: [
+        {
+            type: 'object_interaction',
+            options: [ 'chop down', 'chop' ],
+            objectIds: getTreeIds(),
+            strength: 'normal',
+            task: {
+                canActivate,
+                activate,
+                onComplete,
+                interval: 1
+            }
+        } as ObjectInteractionActionHook
+    ]
+};

--- a/src/plugins/skills/woodcutting/woodcutting-task.ts
+++ b/src/plugins/skills/woodcutting/woodcutting-task.ts
@@ -69,14 +69,12 @@ export const activate = (task: TaskExecutor<ObjectInteractionAction>, taskIterat
 
     // Check if the amount of ticks passed equal the tools pulses.
     if(taskIteration % 3 === 0 && taskIteration != 0) {
-        const successChance = randomBetween(0, 255);
 
         let toolLevel = tool.level - 1;
         if(tool.itemId === 1349 || tool.itemId === 1267) {
             toolLevel = 2;
         }
 
-        const percentNeeded = tree.baseChance + toolLevel + actor.skills.woodcutting.level;
         const succeeds = canCut(tree, toolLevel, actor.skills.woodcutting.level);
         if(succeeds) {
             const targetName: string = findItem(tree.itemId).name.toLowerCase();

--- a/src/plugins/skills/woodcutting/woodcutting-task.ts
+++ b/src/plugins/skills/woodcutting/woodcutting-task.ts
@@ -1,126 +1,142 @@
-
-import {
-    ObjectInteractionAction,
-    TaskExecutor
-} from '@engine/action';
 import { Skill } from '@engine/world/actor/skills';
 import { canInitiateHarvest } from '@engine/world/skill-util/harvest-skill';
-import { getTreeFromHealthy, getTreeIds, IHarvestable } from '@engine/world/config/harvestable-object';
+import { getTreeFromHealthy, IHarvestable } from '@engine/world/config/harvestable-object';
 import { randomBetween } from '@engine/util/num';
 import { colorText } from '@engine/util/strings';
 import { colors } from '@engine/util/colors';
 import { rollBirdsNestType } from '@engine/world/skill-util/harvest-roll';
 import { soundIds } from '@engine/world/config/sound-ids';
-import { Axe, getAxe, HarvestTool } from '@engine/world/config/harvest-tool';
-import { findItem } from '@engine/config/config-handler';
+import { findItem, findObject } from '@engine/config/config-handler';
 import { activeWorld } from '@engine/world';
 import { canCut } from './chance';
+import { ActorLandscapeObjectInteractionTask } from '@engine/task/impl';
+import {  Player } from '@engine/world/actor';
+import { LandscapeObject } from '@runejs/filestore';
+import { logger } from '@runejs/common';
 
-export const canActivate = (task: TaskExecutor<ObjectInteractionAction>, taskIteration: number): boolean => {
-    const { actor, actionData: { position, object, player } } = task;
-    const tree = getTreeFromHealthy(object.objectId);
+class WoodcuttingTask extends ActorLandscapeObjectInteractionTask<Player> {
+    private treeInfo: IHarvestable;
+    private elapsedTicks = 0;
 
-    if(!tree) {
-        return false;
-    }
+    constructor(
+        player: Player,
+        landscapeObject: LandscapeObject,
+        sizeX: number,
+        sizeY: number
+    ) {
+        super(
+            player,
+            landscapeObject,
+            sizeX,
+            sizeY
+        );
 
-    const tool = actor.isPlayer ? canInitiateHarvest(player, tree, Skill.WOODCUTTING) : getAxe(Axe.STEEL);
-
-    if(!tool) {
-        return false;
-    }
-
-    task.session.tool = tool;
-    task.session.tree = tree;
-
-    if(taskIteration === 0) {
-        // First run
-
-        if(actor.isPlayer) {
-            player.sendMessage('You swing your axe at the tree.');
+        if (!landscapeObject) {
+            this.stop();
+            return;
         }
 
-        actor.face(position);
-        actor.playAnimation(tool.animation);
+        this.treeInfo = getTreeFromHealthy(landscapeObject.objectId);
+        if (!this.treeInfo) {
+            this.stop();
+            return;
+        }
     }
 
-    return true;
-};
+    public execute(): void {
+        super.execute();
 
-
-export const activate = (task: TaskExecutor<ObjectInteractionAction>, taskIteration: number): boolean => {
-    const { actor, player, actionData, session } = task.getDetails();
-    const { position: objectPosition, object: actionObject } = actionData;
-    const tree: IHarvestable = session.tree;
-    const tool: HarvestTool = session.tool;
-
-    // Cancel if the actor no longer has their tool or level requirements.
-    if(!tool || !tree) {
-        return false;
-    }
-
-    // Grab the tree manually every loop so that we can make sure it's still alive.
-    const { object } = activeWorld.findObjectAtLocation(actor, actionObject.objectId, objectPosition);
-
-    if(!object) {
-        // Tree has been chopped down, cancel.
-        return false;
-    }
-
-    // Check if the amount of ticks passed equal the tools pulses.
-    if(taskIteration % 3 === 0 && taskIteration != 0) {
-
-        let toolLevel = tool.level - 1;
-        if(tool.itemId === 1349 || tool.itemId === 1267) {
-            toolLevel = 2;
+        if (!this.isActive || !this.landscapeObject) {
+            return;
         }
 
-        const succeeds = canCut(tree, toolLevel, actor.skills.woodcutting.level);
-        if(succeeds) {
-            const targetName: string = findItem(tree.itemId).name.toLowerCase();
+        // store the tick count before incrementing so we don't need to keep track of it in all the separate branches
+        const taskIteration = this.elapsedTicks++;
 
-            if(actor.inventory.hasSpace()) {
-                const itemToAdd = tree.itemId;
-                const roll = randomBetween(1, 256);
+        const tool = canInitiateHarvest(this.actor, this.treeInfo, Skill.WOODCUTTING);
 
-                if(roll === 1) { // Bird nest chance
-                    player?.sendMessage(colorText(`A bird's nest falls out of the tree.`, colors.red));
-                    activeWorld.globalInstance.spawnWorldItem(rollBirdsNestType(), actor.position,
-                        { owner: player || null, expires: 300 });
-                } else { // Standard log chopper
-                    player?.sendMessage(`You manage to chop some ${targetName}.`);
-                    actor.giveItem(itemToAdd);
+        if (!tool) {
+            this.stop();
+            return;
+        }
+
+        if(taskIteration === 0) {
+            this.actor.sendMessage('You swing your axe at the tree.');
+            this.actor.face(this.landscapeObjectPosition);
+            this.actor.playAnimation(tool.animation);
+            return;
+        }
+
+        if(taskIteration % 3 === 0) {
+
+            let toolLevel = tool.level - 1;
+            if(tool.itemId === 1349 || tool.itemId === 1267) {
+                toolLevel = 2;
+            }
+
+            const succeeds = canCut(this.treeInfo, toolLevel, this.actor.skills.woodcutting.level);
+            if(succeeds) {
+                const targetName: string = findItem(this.treeInfo.itemId).name.toLowerCase();
+
+                if(this.actor.inventory.hasSpace()) {
+                    const itemToAdd = this.treeInfo.itemId;
+                    const roll = randomBetween(1, 256);
+
+                    if(roll === 1) { // Bird nest chance
+                        this.actor.sendMessage(colorText(`A bird's nest falls out of the tree.`, colors.red));
+                        activeWorld.globalInstance.spawnWorldItem(rollBirdsNestType(), this.actor.position,
+                            { owner: this.actor || null, expires: 300 });
+                    } else { // Standard log chopper
+                        this.actor.sendMessage(`You manage to chop some ${targetName}.`);
+                        this.actor.giveItem(itemToAdd);
+                    }
+
+                    this.actor.skills.woodcutting.addExp(this.treeInfo.experience);
+
+                    if(randomBetween(0, 100) <= this.treeInfo.break) {
+                        this.actor.playSound(soundIds.oreDepeleted);
+                        this.actor.instance.replaceGameObject(this.treeInfo.objects.get(this.landscapeObject.objectId),
+                            this.landscapeObject, randomBetween(this.treeInfo.respawnLow, this.treeInfo.respawnHigh));
+                        this.stop();
+                        return;
+                    }
+                } else {
+                    this.actor.sendMessage(`Your inventory is too full to hold any more ${targetName}.`, true);
+                    this.actor.playSound(soundIds.inventoryFull);
+                    this.stop();
+                    return;
                 }
-
-                player?.skills.woodcutting.addExp(tree.experience);
-
-                if(randomBetween(0, 100) <= tree.break) {
-                    player?.playSound(soundIds.oreDepeleted);
-                    actor.instance.replaceGameObject(tree.objects.get(actionObject.objectId),
-                        object, randomBetween(tree.respawnLow, tree.respawnHigh));
-                    return false;
-                }
-            } else {
-                player?.sendMessage(
-                    `Your inventory is too full to hold any more ${targetName}.`, true);
-                player?.playSound(soundIds.inventoryFull);
-                return false;
+            }
+        } else {
+            if(taskIteration % 1 === 0) {
+                const randomSoundIdx = Math.floor(Math.random() * soundIds.axeSwing.length);
+                this.actor.playSound(soundIds.axeSwing[randomSoundIdx], 7, 0);
             }
         }
-    } else {
-        if(taskIteration % 1 === 0 && taskIteration !== 0) {
-            const randomSoundIdx = Math.floor(Math.random() * soundIds.axeSwing.length);
-            player?.playSound(soundIds.axeSwing[randomSoundIdx], 7, 0);
+
+        if(taskIteration % 3 === 0) {
+            this.actor.playAnimation(tool.animation);
         }
+
     }
 
-    if(taskIteration % 3 === 0 && taskIteration !== 0) {
-        actor.playAnimation(tool.animation);
+    public onStop(): void {
+        super.onStop();
+
+        this.actor.stopAnimation();
+    }
+}
+
+export function runWoodcuttingTask(player: Player, landscapeObject: LandscapeObject): void {
+    const objectConfig = findObject(landscapeObject.objectId);
+
+    if (!objectConfig) {
+        logger.warn(`Player ${player.username} attempted to run a woodcutting task on an invalid object (id: ${landscapeObject.objectId})`);
+        return;
     }
 
-    return true;
-};
+    const sizeX = objectConfig.rendering.sizeX;
+    const sizeY = objectConfig.rendering.sizeY;
 
-export const onComplete = (task: TaskExecutor<ObjectInteractionAction>): void => {
-    task.actor.stopAnimation();
-};
+    player.enqueueTask(WoodcuttingTask, [ landscapeObject, sizeX, sizeY ]);
+}


### PR DESCRIPTION
Switch woodcutting to using JKM's new tick based task system. First few commits are refactoring prep. The code structure has been preserved.

There is still a bug with walk to animation playing too soon, resulting in the player cutting at a distance. This will be fixed in the future when we get the walking working with the new tick based task system too.

We're also lacking quite a few tree objectIds in the list of trees that can be cut. I will capture this data and add it in soon.