### PR TITLE
feat: create Prayer plugin using task infrastructure

### DIFF
--- a/src/engine/net/inbound-packets/foo.packet.ts
+++ b/src/engine/net/inbound-packets/foo.packet.ts
@@ -1,0 +1,32 @@
+import { logger } from '@runejs/common';
+import { widgets } from '@engine/config';
+import { Player } from '@engine/world/actor';
+import { PacketData } from '@engine/net';
+import { Position } from '@engine/world';
+
+/**
+ * Parses the item on world item packet and calls the `item_on_world_item` action pipeline.
+ *
+ * This will check that the item being used is in the player's inventory, and that the world item exists in the correct location.
+ * The action pipeline will not be called if either of these conditions are not met.
+ *
+ * @param player The player that sent the packet.
+ * @param packet The packet to parse.
+ *
+ * @author jameskmonger
+ */
+const fooPacket = (player: Player, packet: PacketData) => {
+    const { buffer } = packet;
+
+    const a = buffer.get('short', 'u', 'be');
+    const b = buffer.get('short', 'u', 'be');
+    const c = buffer.get('short', 'u', 'le');
+
+    player.sendMessage(`a: ${a}, b: ${b}, c: ${c}`);
+};
+
+export default {
+    opcode: 65,
+    size: 6,
+    handler: fooPacket
+};

--- a/src/plugins/skills/prayer/data/messages.ts
+++ b/src/plugins/skills/prayer/data/messages.ts
@@ -1,0 +1,7 @@
+import { PrayerDetail } from '../types';
+
+export const prayerLevelTooLow = (prayer: PrayerDetail) => {
+    return `You need a Prayer level of ${prayer.level} to use ${prayer.name}.`;
+};
+
+export const runOutOfPrayerPoints = 'You have run out of prayer points. You can recharge at an altar.';

--- a/src/plugins/skills/prayer/data/prayers.ts
+++ b/src/plugins/skills/prayer/data/prayers.ts
@@ -1,0 +1,136 @@
+import { soundIds } from '@engine/world/config';
+import { PrayerDetail, PrayerGroup } from '../types';
+
+// config IDs (prayers enabled)
+
+// 83 - thick skin
+// 84 - burst of strength
+// 85 - clarity of thought
+
+// 99 - redemption
+// 100 - smite
+
+// 862 - sharp eye
+// 863 - mystic will
+// 864 - hawk eye
+// 865 - mystic lore
+// 866 - eagle eye
+// 867 - mystic might
+
+// var prayers = [
+//     // [index - prayer or curse? - name - image filename suffix - drain rate per game tick - {indexes of incompatible prayers} - currently active or not?]
+//     [0,'prayer','Thick Skin','thick_skin',(10/12),{5:0,13:0,25:0,27:0,28:0,29:0},0],
+//     [1,'prayer','Burst of Strength','burst_of_strength',(10/12),{3:0,4:0,6:0,11:0,12:0,14:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [2,'prayer','Clarity of Thought','clarity_of_thought',(10/12),{3:0,4:0,7:0,11:0,12:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [3,'prayer','Sharp Eye','sharp_eye',(10/12),{1:0,2:0,4:0,6:0,7:0,11:0,12:0,14:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [4,'prayer','Mystic Will','mystic_will',(10/12),{1:0,2:0,3:0,6:0,7:0,11:0,12:0,14:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [5,'prayer','Rock Skin','rock_skin',(10/6),{0:0,13:0,25:0,27:0,28:0,29:0},0],
+//     [6,'prayer','Superhuman Strength','superhuman_strength',(10/6),{1:0,3:0,4:0,11:0,12:0,14:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [7,'prayer','Improved Reflexes','improved_reflexes',(10/6),{2:0,3:0,4:0,11:0,12:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [8,'prayer','Rapid Restore','rapid_restore',(10/36),{},0],
+//     [9,'prayer','Rapid Heal','rapid_heal',(10/18),{},0],
+//     [10,'prayer','Protect Item','protect_item',(10/18),{},0],
+//     [11,'prayer','Hawk Eye','hawk_eye',(10/6),{1:0,2:0,3:0,4:0,6:0,7:0,12:0,14:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [12,'prayer','Mystic Lore','mystic_lore',(10/6),{1:0,2:0,3:0,4:0,6:0,7:0,11:0,14:0,15:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [13,'prayer','Steel Skin','steel_skin',(10/3),{0:0,5:0,25:0,27:0,28:0,29:0},0],
+//     [14,'prayer','Ultimate Strength','ultimate_strength',(10/3),{1:0,3:0,4:0,6:0,11:0,12:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [15,'prayer','Incredible Reflexes','incredible_reflexes',(10/3),{2:0,3:0,4:0,7:0,11:0,12:0,20:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [16,'prayer','Protect from Summoning','protect_from_summoning',(10/3),{22:0,23:0,24:0},0],
+//     [17,'prayer','Protect from Magic','protect_from_magic',(10/3),{18:0,19:0,22:0,23:0,24:0},0],
+//     [18,'prayer','Protect from Missiles','protect_from_missiles',(10/3),{17:0,19:0,22:0,23:0,24:0},0],
+//     [19,'prayer','Protect from Melee','protect_from_melee',(10/3),{17:0,18:0,22:0,23:0,24:0},0],
+//     [20,'prayer','Eagle Eye','eagle_eye',(10/3),{1:0,2:0,3:0,4:0,6:0,7:0,11:0,12:0,14:0,15:0,21:0,25:0,27:0,28:0,29:0},0],
+//     [21,'prayer','Mystic Might','mystic_might',(10/3),{1:0,2:0,3:0,4:0,6:0,7:0,11:0,12:0,14:0,15:0,20:0,25:0,27:0,28:0,29:0},0],
+//     [22,'prayer','Retribution','retribution',(10/12),{16:0,17:0,18:0,19:0,23:0,24:0},0],
+//     [23,'prayer','Redemption','redemption',(10/6),{16:0,17:0,18:0,19:0,22:0,24:0},0],
+//     [24,'prayer','Smite','smite',(10/1.8),{16:0,17:0,18:0,19:0,22:0,23:0},0],
+//     [25,'prayer','Chivalry','chivalry',(10/1.8),{0:0,1:0,2:0,3:0,4:0,5:0,6:0,7:0,11:0,12:0,13:0,14:0,15:0,20:0,21:0,27:0,28:0,29:0},0],
+//     [26,'prayer','Rapid Renewal','rapid_renewal',(10/2.4),{},0],
+//     [27,'prayer','Piety','piety',(10/1.5),{0:0,1:0,2:0,3:0,4:0,5:0,6:0,7:0,11:0,12:0,13:0,14:0,15:0,20:0,21:0,25:0,28:0,29:0},0],
+//     [28,'prayer','Rigour','rigour',(5),{0:0,1:0,2:0,3:0,4:0,5:0,6:0,7:0,11:0,12:0,13:0,14:0,15:0,20:0,21:0,25:0,27:0,29:0},0],
+//     [29,'prayer','Augury','augury',(10/1.8),{0:0,1:0,2:0,3:0,4:0,5:0,6:0,7:0,11:0,12:0,13:0,14:0,15:0,20:0,21:0,25:0,27:0,28:0},0],
+//     [30,'curse','Protect Item','protect_item_curse',(10/18),{},0],
+//     [31,'curse','Sap Warrior','sap_warrior',(10/2.4),{40:0,41:0,42:0,43:0,44:0,45:0,46:0,49:0},0],
+//     [32,'curse','Sap Ranger','sap_ranger',(10/2.4),{40:0,41:0,42:0,43:0,44:0,45:0,46:0,49:0},0],
+//     [33,'curse','Sap Mage','sap_mage',(10/2.4),{40:0,41:0,42:0,43:0,44:0,45:0,46:0,49:0},0],
+//     [34,'curse','Sap Spirit','sap_spirit',(10/2.4),{40:0,41:0,42:0,43:0,44:0,45:0,46:0,49:0},0],
+//     [35,'curse','Berserker','berserker',(10/18),{},0],
+//     [36,'curse','Deflect Summoning','deflect_summoning',(10/3),{47:0,48:0},0],
+//     [37,'curse','Deflect Magic','deflect_magic',(10/3),{38:0,39:0,47:0,48:0},0],
+//     [38,'curse','Deflect Missiles','deflect_missiles',(10/3),{37:0,39:0,47:0,48:0},0],
+//     [39,'curse','Deflect Melee','deflect_melee',(10/3),{37:0,38:0,47:0,48:0},0],
+//     [40,'curse','Leech Attack','leech_attack',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [41,'curse','Leech Ranged','leech_ranged',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [42,'curse','Leech Magic','leech_magic',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [43,'curse','Leech Defence','leech_defence',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [44,'curse','Leech Strength','leech_strength',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [45,'curse','Leech Energy','leech_energy',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [46,'curse','Leech Special Attack','leech_special_attack',(10/3.6),{31:0,32:0,33:0,34:0,49:0},0],
+//     [47,'curse','Wrath','wrath',(10/12),{36:0,37:0,38:0,39:0,48:0},0],
+//     [48,'curse','Soul Split','soul_split',(5),{36:0,37:0,38:0,39:0,47:0},0],
+
+export const prayerDetails: PrayerDetail[] = [
+    {
+        key: 'thick_skin',
+        name: 'Thick Skin',
+        level: 1,
+        buttonId: 0,
+        soundId: soundIds.prayer.thick_skin,
+        configId: 83,
+        drainRate: (5 / 6),
+        group: PrayerGroup.DEFENCE
+    },
+    {
+        key: 'burst_of_strength',
+        name: 'Burst of Strength',
+        level: 4,
+        buttonId: 1,
+        soundId: soundIds.prayer.burst_of_strength,
+        configId: 84,
+        drainRate: (5 / 6),
+        group: PrayerGroup.STRENGTH
+    },
+    {
+        key: 'clarity_of_thought',
+        name: 'Clarity of Thought',
+        level: 7,
+        buttonId: 2,
+        soundId: soundIds.prayer.clarity_of_thought,
+        configId: 85,
+        drainRate: (5 / 6),
+        group: PrayerGroup.ATTACK
+    },
+
+    // TODO: Add the rest of the prayers
+
+    {
+        key: 'rock_skin',
+        name: 'Rock Skin',
+        level: 10,
+        buttonId: 3,
+        soundId: soundIds.prayer.rock_skin,
+        configId: 86,
+        drainRate: (5 / 6),
+        group: PrayerGroup.DEFENCE
+    },
+    {
+        key: 'superhuman_strength',
+        name: 'Superhuman Strength',
+        level: 13,
+        buttonId: 4,
+        soundId: soundIds.prayer.superhuman_strength,
+        configId: 87,
+        drainRate: (5 / 6),
+        group: PrayerGroup.STRENGTH
+    },
+    {
+        key: 'improved_reflexes',
+        name: 'Improved Reflexes',
+        level: 16,
+        buttonId: 5,
+        soundId: soundIds.prayer.improved_reflexes,
+        configId: 88,
+        drainRate: (5 / 6),
+        group: PrayerGroup.ATTACK
+    },
+];

--- a/src/plugins/skills/prayer/index.ts
+++ b/src/plugins/skills/prayer/index.ts
@@ -1,5 +1,8 @@
-import { PlayerInitActionHook } from '@engine/action';
+import { ButtonActionHook, PlayerInitActionHook } from '@engine/action';
+import { widgets } from '@engine/config';
+import { prayerDetails } from './data/prayers';
 import { PrayerDrainTask } from './prayer-task';
+import { togglePrayer } from './toggle';
 import { ActivePlayerPrayers } from './types';
 
 export default {
@@ -20,6 +23,22 @@ export default {
 
                 player.enqueueTask(PrayerDrainTask);
             }
-        } as PlayerInitActionHook
+        } as PlayerInitActionHook,
+        {
+            type: 'button',
+            buttonIds: prayerDetails.map(p => p.buttonId),
+            widgetId: widgets.prayerTab,
+            handler: ({ player, buttonId }) => {
+                console.log(`Player ${player.username} clicked prayer button ${buttonId}`);
+
+                const prayer = prayerDetails.find(p => p.buttonId === buttonId);
+
+                if (!prayer) {
+                    return;
+                }
+
+                togglePrayer(player, prayer);
+            }
+        } as ButtonActionHook
     ]
 };

--- a/src/plugins/skills/prayer/index.ts
+++ b/src/plugins/skills/prayer/index.ts
@@ -1,0 +1,25 @@
+import { PlayerInitActionHook } from '@engine/action';
+import { PrayerDrainTask } from './prayer-task';
+import { ActivePlayerPrayers } from './types';
+
+export default {
+    pluginId: 'rs:prayer_jkm',
+    hooks: [
+        /**
+         * Initialise the player's prayer state and start the prayer drain task.
+         */
+        {
+            type: 'player_init',
+            handler: ({ player }) => {
+                // split these out into two lines because `ActivePlayerPrayers` is quite a complex type
+                // and `metadata` has no type information, so this gives us some type safety
+                const activePrayers: ActivePlayerPrayers = new Map();
+                player.metadata.activePrayers = activePrayers;
+
+                player.metadata.prayerDrainCounter = 0;
+
+                player.enqueueTask(PrayerDrainTask);
+            }
+        } as PlayerInitActionHook
+    ]
+};

--- a/src/plugins/skills/prayer/prayer-task.ts
+++ b/src/plugins/skills/prayer/prayer-task.ts
@@ -1,0 +1,102 @@
+import { ActorTask } from '@engine/task/impl';
+import { Player, Skill } from '@engine/world/actor';
+import { logger } from '@runejs/common';
+import { prayerDetails } from './data/prayers';
+import { ActivePlayerPrayers } from './types';
+
+/**
+ * A task that handles prayer drain for a player.
+ *
+ * Every tick, the drain rate for each active prayer is applied to the player's cumulative 'prayer drain counter'.
+ * When this counter reaches the 'drain resistance' (a function of the player's prayer bonus), the player loses a prayer point.
+ *
+ * https://oldschool.runescape.wiki/w/Prayer#Prayer_drain_mechanics
+ *
+ * @author jameskmonger
+ */
+export class PrayerDrainTask extends ActorTask<Player> {
+    public execute() {
+        if (!this.isActive) {
+            return;
+        }
+
+        const prayerLevel = this.actor.skills.getLevel(Skill.PRAYER);
+        if (prayerLevel < 1) {
+            return;
+        }
+
+        for (const prayerKey of this.activePrayers.values()) {
+            if (!prayerKey) {
+                continue;
+            }
+
+            const prayerDetail = prayerDetails.find((detail) => detail.key === prayerKey);
+            if (!prayerDetail) {
+                logger.warn(`Could not find prayer detail for prayer key ${prayerKey}`);
+                continue;
+            }
+
+            this.prayerDrainCounter += prayerDetail.drainRate;
+        }
+
+        // the player's prayer level is only reduced when the prayer drain counter surpasses the drain resistance
+        if (this.prayerDrainCounter < this.drainResistance) {
+            return;
+        }
+
+        this.prayerDrainCounter -= this.drainResistance;
+
+        this.actor.skills.prayer.level -= 1;
+        this.actor.outgoingPackets.updateSkill(Skill.PRAYER, this.actor.skills.prayer.level, this.actor.skills.prayer.exp);
+    }
+
+    /**
+     * Gets the active prayers for this player.
+     *
+     * @returns a {@link ActivePlayerPrayers} map for this player containing the active prayer for each prayer group.
+     */
+    private get activePrayers(): ActivePlayerPrayers {
+        return this.actor.metadata.activePrayers;
+    }
+
+    /**
+     * Get the player's current prayer drain counter.
+     *
+     * This can increment over many ticks, and will result in the player's prayer points being reduced
+     * when this surpasses the player's prayer resistance.
+     *
+     * @returns The prayer drain counter.
+     */
+    private get prayerDrainCounter(): number {
+        return this.actor.metadata.prayerDrainCounter;
+    }
+
+    /**
+     * Set the player's current prayer drain counter.
+     *
+     * @param value The new prayer drain counter.
+     */
+    private set prayerDrainCounter(value: number) {
+        this.actor.metadata.prayerDrainCounter = value;
+    }
+
+    /**
+     * Get the current prayer drain resistance for this player based on their prayer bonus.
+     *
+     * @returns The prayer drain resistance.
+     */
+    private get drainResistance(): number {
+        return 2 * this.prayerBonus + 60;
+    }
+
+    /**
+     * (UNIMPLEMENTED) Gets the current prayer bonus for this player.
+     *
+     * TODO get the prayer bonus from equipment
+     *
+     * @returns The prayer bonus.
+     */
+    private get prayerBonus(): number {
+        return 0;
+    }
+}

--- a/src/plugins/skills/prayer/toggle.ts
+++ b/src/plugins/skills/prayer/toggle.ts
@@ -1,0 +1,67 @@
+import { Player } from '@engine/world/actor';
+import { logger } from '@runejs/common';
+import { prayerLevelTooLow, runOutOfPrayerPoints } from './data/messages';
+import { prayerDetails } from './data/prayers';
+import { ActivePlayerPrayers, PrayerDetail, PrayerKey } from './types';
+
+export function togglePrayer(player: Player, prayer: PrayerDetail) {
+    // TODO remove explicit typing here
+    const activePrayers: ActivePlayerPrayers = player.metadata.activePrayers;
+
+    if (!prayer) {
+        logger.warn(`Could not find prayer details for prayer key ${prayer.key}`);
+        return;
+    }
+
+    const currentPrayerLevel = player.skills.prayer.level;
+
+    if (currentPrayerLevel === 0) {
+        player.sendMessage(runOutOfPrayerPoints);
+        return;
+    }
+
+    const playerPrayerLevel = player.skills.getLevelForExp(player.skills.prayer.exp);
+
+    if (playerPrayerLevel < prayer.level) {
+        player.sendMessage(prayerLevelTooLow(prayer));
+
+        // TODO should we be turning the prayer off here? or just config update?
+        //      this will currently clear other prayers in the same group
+        turnPrayerOff(player, prayer);
+        return;
+    }
+
+    const currentPrayer = activePrayers.get(prayer.group);
+
+    // player currently has no prayer active in this group
+    if (!currentPrayer) {
+        turnPrayerOn(player, prayer);
+        return;
+    }
+
+    // this prayer is already active, so turn it off
+    if (currentPrayer === prayer.key) {
+        turnPrayerOff(player, prayer);
+        return;
+    }
+
+    const currentPrayerDetails = prayerDetails.find(p => p.key === currentPrayer);
+    if (!currentPrayerDetails) {
+        logger.warn(`Could not find prayer details for currentPrayer key ${currentPrayer}`);
+        return;
+    }
+
+    turnPrayerOff(player, currentPrayerDetails);
+    turnPrayerOn(player, prayer);
+}
+
+function turnPrayerOn(player: Player, prayer: PrayerDetail) {
+    player.metadata.activePrayers.set(prayer.group, prayer.key);
+    player.outgoingPackets.updateClientConfig(prayer.configId, 1);
+    player.playSound(prayer.soundId);
+}
+
+function turnPrayerOff(player: Player, prayer: PrayerDetail) {
+    player.metadata.activePrayers.set(prayer.group, null);
+    player.outgoingPackets.updateClientConfig(prayer.configId, 0);
+}

--- a/src/plugins/skills/prayer/types.ts
+++ b/src/plugins/skills/prayer/types.ts
@@ -1,0 +1,82 @@
+export enum Prayer {
+    THICK_SKIN = 0,
+    BURST_OF_STRENGTH = 1,
+    CLARITY_OF_THOUGHT = 2,
+    SHARP_EYE = 3,
+    MYSTIC_WILL = 4,
+    ROCK_SKIN = 5,
+    SUPERHUMAN_STRENGTH = 6,
+    IMPROVED_REFLEXES = 7,
+    RAPID_RESTORE = 8,
+    RAPID_HEAL = 9,
+    PROTECT_ITEM = 10,
+    HAWK_EYE = 11,
+    MYSTIC_LORE = 12,
+    STEEL_SKIN = 13,
+    ULTIMATE_STRENGTH = 14,
+    INCREDIBLE_REFLEXES = 15,
+    PROTECT_FROM_MAGIC = 16,
+    PROTECT_FROM_MISSILES = 17,
+    PROTECT_FROM_MELEE = 18,
+    EAGLE_EYE = 19,
+    MYSTIC_MIGHT = 20,
+    RETRIBUTION = 21,
+    REDEMPTION = 22,
+    SMITE = 23,
+}
+
+export type PrayerKey = 'thick_skin'
+    | 'burst_of_strength'
+    | 'clarity_of_thought'
+    | 'sharp_eye'
+    | 'mystic_will'
+    | 'rock_skin'
+    | 'superhuman_strength'
+    | 'improved_reflexes'
+    | 'rapid_restore'
+    | 'rapid_heal'
+    | 'protect_item'
+    | 'hawk_eye'
+    | 'mystic_lore'
+    | 'steel_skin'
+    | 'ultimate_strength'
+    | 'incredible_reflexes'
+    | 'protect_from_magic'
+    | 'protect_from_missiles'
+    | 'protect_from_melee'
+    | 'eagle_eye'
+    | 'mystic_might'
+    | 'retribution'
+    | 'redemption'
+    | 'smite';
+
+export enum PrayerGroup {
+    DEFENCE = 0,
+    STRENGTH = 1,
+    ATTACK = 2,
+    MAGE_RANGE = 3,
+    OVER_HEAD = 4
+}
+
+export type PrayerDetail = {
+    readonly key: PrayerKey;
+    readonly name: string;
+    readonly level: number;
+    readonly buttonId: number;
+    readonly soundId: number;
+    readonly drainRate: number;
+    readonly group: PrayerGroup;
+};
+
+export type ActivePlayerPrayers = Map<PrayerGroup, PrayerKey | null>;
+
+export enum PrayerIcons {
+    NONE = -1,
+    PROTECT_FROM_MELEE = 0,
+    PROTECT_FROM_MISSILES = 1,
+    PROTECT_FROM_MAGIC = 2,
+    RETRIBUTION = 3,
+    SMITE = 4,
+    REDEMPTION = 5,
+    PROTECT_FROM_MAGIC_AND_MISSILES = 6,
+}

--- a/src/plugins/skills/prayer/types.ts
+++ b/src/plugins/skills/prayer/types.ts
@@ -64,6 +64,7 @@ export type PrayerDetail = {
     readonly level: number;
     readonly buttonId: number;
     readonly soundId: number;
+    readonly configId: number;
     readonly drainRate: number;
     readonly group: PrayerGroup;
 };


### PR DESCRIPTION
- [x] prayer drain
- [ ] enable/disable prayers
- [ ] prayer effects for the 5% melee ones
- [ ] overhead icons for overhead prayers
- [ ] only enable one prayer from each group (e.g. not protecting mage + range at same time)